### PR TITLE
Expose missing Segment functions

### DIFF
--- a/lib/segment.ex
+++ b/lib/segment.ex
@@ -4,6 +4,7 @@ defmodule Segment do
   """
 
   use Application
+  alias Segment.Context
 
   @api Application.get_env(:segment, :api) || Segment.Server
 
@@ -18,10 +19,21 @@ defmodule Segment do
     Supervisor.start_link(children, opts)
   end
 
+  defdelegate track(user_id, event, properties \\ %{}, context \\ Context.new()), to: @api
   defdelegate track(t), to: @api
+
+  defdelegate identify(user_id, traits, context \\ Context.new()), to: @api
   defdelegate identify(i), to: @api
+
+  defdelegate screen(user_id, name, properties \\ %{}, context \\ Context.new()), to: @api
   defdelegate screen(s), to: @api
+
+  defdelegate alias_user(user_id, previous_id, context \\ Context.new()), to: @api
   defdelegate alias_user(a), to: @api
+
+  defdelegate group(user_id, group_id, traits \\ %{}, context \\ Context.new()), to: @api
   defdelegate group(g), to: @api
+
+  defdelegate page(user_id, name, properties \\ %{}, context \\ Context.new()), to: @api
   defdelegate page(p), to: @api
 end


### PR DESCRIPTION
when merged this PR will add possibility to call segment functions that were not exposed previously, basically adds functionality from lswith's version: 
https://github.com/lswith/analytics-elixir/blob/master/lib/segment.ex