### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Make sure you reset the sandbox state between tests.
 If you're using Phoenix this is as easy as adding:
 
 ```elixir
-# test/support/conn_case.ex
+# test/support/{conn_case.ex, data_case.ex, channel_case.ex} 
 setup tags
   :ok = Segment.Sandbox.checkout()
   ...


### PR DESCRIPTION
It wasn't clear from the docs that `Sandbox.checkout()` should be called in all `_case.ex` support files.