### PR TITLE
Fix alias_user arguments order to match segment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ or the full way using a struct with all the possible options for the screen call
 > Note that we need to use `alias_user` here instead of Segment's `alias`, due to `alias` being reserved in Elixir.
 
 ```elixir
-Segment.alias_user(user_id, previous_id)
+Segment.alias_user(previous_id, user_id)
 ```
 
 or the full way using a struct with all the possible options for the alias call:

--- a/doc/Segment.Analytics.html
+++ b/doc/Segment.Analytics.html
@@ -95,7 +95,7 @@ Segment.Analytics
 </div>
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#alias_user/3">alias_user(user_id, previous_id, context \\ Context.new())</a>
+    <a href="#alias_user/3">alias_user(previous_id, user_id, context \\ Context.new())</a>
   </div>
 </div>
 <div class="summary-row">
@@ -166,7 +166,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">alias_user(a)</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L42" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L34" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -182,8 +182,8 @@ Functions          </h1>
       <span class="icon-link" aria-hidden="true"></span>
       <span class="sr-only">Link to this function</span>
     </a>
-    <h1 class="signature">alias_user(user_id, previous_id, context \\ Context.new())</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L46" class="view-source" rel="help" title="View Source">
+    <h1 class="signature">alias_user(previous_id, user_id, context \\ Context.new())</span>
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L38" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -198,7 +198,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">group(g)</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L53" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L43" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -217,7 +217,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">group(user_id, group_id, traits \\ %{}, context \\ Context.new())</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L57" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L47" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -232,7 +232,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">identify(i)</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L19" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L16" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -251,7 +251,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">identify(user_id, traits \\ %{}, context \\ Context.new())</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L23" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L20" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -266,7 +266,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">page(p)</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L65" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L52" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -287,7 +287,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">page(user_id, name \\ &quot;&quot;, properties \\ %{}, context \\ Context.new())</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L69" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L56" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -302,7 +302,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">screen(s)</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L30" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L25" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>
@@ -323,7 +323,7 @@ Functions          </h1>
       <span class="sr-only">Link to this function</span>
     </a>
     <h1 class="signature">screen(user_id, name \\ &quot;&quot;, properties \\ %{}, context \\ Context.new())</span>
-      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L34" class="view-source" rel="help" title="View Source">
+      <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/analytics.ex#L29" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>
      </a>

--- a/doc/Segment.Http.html
+++ b/doc/Segment.Http.html
@@ -1160,14 +1160,14 @@ request is successful, <code class="inline">{:error, reason}</code> otherwise.</
   Examples
 </h2>
 
-<pre><code class="nohighlight makeup elixir"><span class="n">request</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="p" data-group-id="6013812454-1">%</span><span class="nc" data-group-id="6013812454-1">HTTPoison.Request</span><span class="p" data-group-id="6013812454-1">{</span><span class="w">
+<pre><code class="nohighlight makeup elixir"><span class="n">request</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="p" data-group-id="2377518080-1">%</span><span class="nc" data-group-id="2377518080-1">HTTPoison.Request</span><span class="p" data-group-id="2377518080-1">{</span><span class="w">
   </span><span class="ss">method</span><span class="p">:</span><span class="w"> </span><span class="ss">:post</span><span class="p">,</span><span class="w">
   </span><span class="ss">url</span><span class="p">:</span><span class="w"> </span><span class="s">&quot;https://my.website.com&quot;</span><span class="p">,</span><span class="w">
   </span><span class="ss">body</span><span class="p">:</span><span class="w"> </span><span class="s">&quot;{</span><span class="se">\&quot;</span><span class="s">foo</span><span class="se">\&quot;</span><span class="s">: 3}&quot;</span><span class="p">,</span><span class="w">
-  </span><span class="ss">headers</span><span class="p">:</span><span class="w"> </span><span class="p" data-group-id="6013812454-2">[</span><span class="p" data-group-id="6013812454-3">{</span><span class="s">&quot;Accept&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p" data-group-id="6013812454-3">}</span><span class="p" data-group-id="6013812454-2">]</span><span class="w">
-</span><span class="p" data-group-id="6013812454-1">}</span><span class="w">
+  </span><span class="ss">headers</span><span class="p">:</span><span class="w"> </span><span class="p" data-group-id="2377518080-2">[</span><span class="p" data-group-id="2377518080-3">{</span><span class="s">&quot;Accept&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p" data-group-id="2377518080-3">}</span><span class="p" data-group-id="2377518080-2">]</span><span class="w">
+</span><span class="p" data-group-id="2377518080-1">}</span><span class="w">
 
-</span><span class="n">request</span><span class="p" data-group-id="6013812454-4">(</span><span class="n">request</span><span class="p" data-group-id="6013812454-4">)</span></code></pre>
+</span><span class="n">request</span><span class="p" data-group-id="2377518080-4">(</span><span class="n">request</span><span class="p" data-group-id="2377518080-4">)</span></code></pre>
   </section>
 </section>
 <section class="detail" id="request/5">
@@ -1220,7 +1220,7 @@ request is successful, <code class="inline">{:error, reason}</code> otherwise.</
   Examples
 </h2>
 
-<pre><code class="nohighlight makeup elixir"><span class="n">request</span><span class="p" data-group-id="8952756690-1">(</span><span class="ss">:post</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;https://my.website.com&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;{</span><span class="se">\&quot;</span><span class="s">foo</span><span class="se">\&quot;</span><span class="s">: 3}&quot;</span><span class="p">,</span><span class="w"> </span><span class="p" data-group-id="8952756690-2">[</span><span class="p" data-group-id="8952756690-3">{</span><span class="s">&quot;Accept&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p" data-group-id="8952756690-3">}</span><span class="p" data-group-id="8952756690-2">]</span><span class="p" data-group-id="8952756690-1">)</span></code></pre>
+<pre><code class="nohighlight makeup elixir"><span class="n">request</span><span class="p" data-group-id="4044619744-1">(</span><span class="ss">:post</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;https://my.website.com&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;{</span><span class="se">\&quot;</span><span class="s">foo</span><span class="se">\&quot;</span><span class="s">: 3}&quot;</span><span class="p">,</span><span class="w"> </span><span class="p" data-group-id="4044619744-2">[</span><span class="p" data-group-id="4044619744-3">{</span><span class="s">&quot;Accept&quot;</span><span class="p">,</span><span class="w"> </span><span class="s">&quot;application/json&quot;</span><span class="p" data-group-id="4044619744-3">}</span><span class="p" data-group-id="4044619744-2">]</span><span class="p" data-group-id="4044619744-1">)</span></code></pre>
   </section>
 </section>
 <section class="detail" id="request!/5">

--- a/doc/Segment.Sandbox.html
+++ b/doc/Segment.Sandbox.html
@@ -99,7 +99,7 @@ data is correctly sent to segment.io.</p>
 </div>
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#alias_user/3">alias_user(user_id, previous_id, context \\ Context.new())</a>
+    <a href="#alias_user/3">alias_user(previous_id, user_id, context \\ Context.new())</a>
   </div>
 </div>
 <div class="summary-row">
@@ -233,7 +233,7 @@ Functions          </h1>
       <span class="icon-link" aria-hidden="true"></span>
       <span class="sr-only">Link to this function</span>
     </a>
-    <h1 class="signature">alias_user(user_id, previous_id, context \\ Context.new())</span>
+    <h1 class="signature">alias_user(previous_id, user_id, context \\ Context.new())</span>
       <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/sandbox.ex#L76" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>

--- a/doc/Segment.Server.html
+++ b/doc/Segment.Server.html
@@ -100,7 +100,7 @@ for clients.</p>
 </div>
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#alias_user/3">alias_user(user_id, previous_id, context \\ Context.new())</a>
+    <a href="#alias_user/3">alias_user(previous_id, user_id, context \\ Context.new())</a>
   </div>
 </div>
 <div class="summary-row">
@@ -198,7 +198,7 @@ Functions          </h1>
       <span class="icon-link" aria-hidden="true"></span>
       <span class="sr-only">Link to this function</span>
     </a>
-    <h1 class="signature">alias_user(user_id, previous_id, context \\ Context.new())</span>
+    <h1 class="signature">alias_user(previous_id, user_id, context \\ Context.new())</span>
       <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment/server.ex#L56" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>

--- a/doc/Segment.html
+++ b/doc/Segment.html
@@ -99,7 +99,7 @@ Segment
 </div>
 <div class="summary-row">
   <div class="summary-signature">
-    <a href="#alias_user/3">alias_user(user_id, previous_id, context \\ Context.new())</a>
+    <a href="#alias_user/3">alias_user(previous_id, user_id, context \\ Context.new())</a>
   </div>
     <div class="summary-synopsis"><p>See <a href="Segment.Server.html#alias_user/3"><code class="inline">Segment.Server.alias_user/3</code></a>.</p></div>
 </div>
@@ -204,7 +204,7 @@ Functions          </h1>
       <span class="icon-link" aria-hidden="true"></span>
       <span class="sr-only">Link to this function</span>
     </a>
-    <h1 class="signature">alias_user(user_id, previous_id, context \\ Context.new())</span>
+    <h1 class="signature">alias_user(previous_id, user_id, context \\ Context.new())</span>
       <a href="https://github.com/joshsmith/segment_elixir/blob/master/lib/segment.ex#L31" class="view-source" rel="help" title="View Source">
        <span class="icon-code" aria-hidden="true"></span>
        <span class="sr-only">View Source</span>

--- a/lib/segment.ex
+++ b/lib/segment.ex
@@ -28,7 +28,7 @@ defmodule Segment do
   defdelegate screen(user_id, name, properties \\ %{}, context \\ Context.new()), to: @api
   defdelegate screen(s), to: @api
 
-  defdelegate alias_user(user_id, previous_id, context \\ Context.new()), to: @api
+  defdelegate alias_user(previous_id, user_id, context \\ Context.new()), to: @api
   defdelegate alias_user(a), to: @api
 
   defdelegate group(user_id, group_id, traits \\ %{}, context \\ Context.new()), to: @api

--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -43,7 +43,7 @@ defmodule Segment.Analytics do
     call(a)
   end
 
-  def alias_user(user_id, previous_id, context \\ Context.new) do
+  def alias_user(previous_id, user_id, context \\ Context.new) do
     %Segment.Alias{ userId: user_id,
                                   previousId: previous_id,
                                   context: context }

--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -8,11 +8,8 @@ defmodule Segment.Analytics do
     call(t)
   end
 
-  def track(user_id, event, properties \\ %{}, context \\ Context.new) do
-    %Segment.Track{ userId: user_id,
-                              event: event,
-                              properties: properties,
-                              context: context }
+  def track(user_id, event, properties \\ %{}, context \\ Context.new()) do
+    %Segment.Track{userId: user_id, event: event, properties: properties, context: context}
     |> call
   end
 
@@ -20,10 +17,8 @@ defmodule Segment.Analytics do
     call(i)
   end
 
-  def identify(user_id, traits \\ %{}, context \\ Context.new) do
-    %Segment.Identify{  userId: user_id,
-                                      traits: traits,
-                                      context: context }
+  def identify(user_id, traits \\ %{}, context \\ Context.new()) do
+    %Segment.Identify{userId: user_id, traits: traits, context: context}
     |> call
   end
 
@@ -31,11 +26,8 @@ defmodule Segment.Analytics do
     call(s)
   end
 
-  def screen(user_id, name \\ "", properties \\ %{}, context \\ Context.new ) do
-    %Segment.Screen{  userId: user_id,
-                                    name: name,
-                                    properties: properties,
-                                    context: context }
+  def screen(user_id, name \\ "", properties \\ %{}, context \\ Context.new()) do
+    %Segment.Screen{userId: user_id, name: name, properties: properties, context: context}
     |> call
   end
 
@@ -43,10 +35,8 @@ defmodule Segment.Analytics do
     call(a)
   end
 
-  def alias_user(previous_id, user_id, context \\ Context.new) do
-    %Segment.Alias{ userId: user_id,
-                                  previousId: previous_id,
-                                  context: context }
+  def alias_user(previous_id, user_id, context \\ Context.new()) do
+    %Segment.Alias{userId: user_id, previousId: previous_id, context: context}
     |> call
   end
 
@@ -54,11 +44,8 @@ defmodule Segment.Analytics do
     call(g)
   end
 
-  def group(user_id, group_id, traits \\ %{}, context \\ Context.new) do
-    %Segment.Group{ userId: user_id,
-                                  groupId: group_id,
-                                  traits: traits,
-                                  context: context }
+  def group(user_id, group_id, traits \\ %{}, context \\ Context.new()) do
+    %Segment.Group{userId: user_id, groupId: group_id, traits: traits, context: context}
     |> call
   end
 
@@ -66,11 +53,8 @@ defmodule Segment.Analytics do
     call(p)
   end
 
-  def page(user_id, name \\ "", properties \\ %{}, context \\ Context.new ) do
-    %Segment.Page{  userId: user_id,
-                                  name: name,
-                                  properties: properties,
-                                  context: context }
+  def page(user_id, name \\ "", properties \\ %{}, context \\ Context.new()) do
+    %Segment.Page{userId: user_id, name: name, properties: properties, context: context}
     |> call
   end
 
@@ -84,17 +68,17 @@ defmodule Segment.Analytics do
   end
 
   defp log_result({_, %{status_code: code}}, function, body) when code in 200..299 do
-    #success
+    # success
     Logger.debug("Segment #{function} call success: #{code} with body: #{body}")
   end
 
   defp log_result({_, %{status_code: code}}, function, body) do
-    #HTTP failure
+    # HTTP failure
     Logger.debug("Segment #{function} call failed: #{code} with body: #{body}")
   end
 
   defp log_result(error, function, body) do
-    #every other failure
+    # every other failure
     Logger.debug("Segment #{function} call failed: #{inspect(error)} with body: #{body}")
   end
 end

--- a/lib/segment/sandbox.ex
+++ b/lib/segment/sandbox.ex
@@ -73,7 +73,7 @@ defmodule Segment.Sandbox do
     Agent.get(__MODULE__, &Map.get(&1, :alias_calls))
   end
 
-  def alias_user(user_id, previous_id, context \\ Context.new()) do
+  def alias_user(previous_id, user_id, context \\ Context.new()) do
     a = %Alias{userId: user_id, previousId: previous_id, context: context}
     alias_user(a)
   end

--- a/lib/segment/server.ex
+++ b/lib/segment/server.ex
@@ -53,7 +53,7 @@ defmodule Segment.Server do
     GenServer.cast(__MODULE__, a)
   end
 
-  def alias_user(user_id, previous_id, context \\ Context.new()) do
+  def alias_user(previous_id, user_id, context \\ Context.new()) do
     a = %Alias{userId: user_id, previousId: previous_id, context: context}
     alias_user(a)
   end


### PR DESCRIPTION
Order of arguments for `alias_user/2` and `alias_user/3` was wrong. This PR changes the order to match docs & other implementations, see: https://segment.com/docs/sources/server/python/#alias